### PR TITLE
fix link to repo_url push view

### DIFF
--- a/coffee/views.coffee
+++ b/coffee/views.coffee
@@ -82,7 +82,7 @@ views["item"] = """
 views["push"] = """
 <li class="item" data-id="{{id}}" data-type="push">
   <span class="corner"></span>
-  <h1>Pushed {{num}} commit(s) to <a href="repo_url">{{repo}}</a></h1>
+  <h1>Pushed {{num}} commit(s) to <a href="{{repo_url}}">{{repo}}</a></h1>
   <ol class="commits">
     {{#commits}}
     <li {{#hidden}}style="display:none;" data-more{{/hidden}}><a href="{{commit_url}}">{{commit}}</a></li>


### PR DESCRIPTION
The template variable wasn't in {{}} so it just made `<a href="repo_url">` not the actual url
